### PR TITLE
Support recursive CSV discovery and source transparency

### DIFF
--- a/wage/settle_person.py
+++ b/wage/settle_person.py
@@ -101,7 +101,7 @@ def _format_source(attendance_source: str | None, payment_source: str | None) ->
     if attendance_source and payment_source:
         if attendance_source == payment_source:
             return f"来源：{attendance_source}"
-        return f"来源：出勤/{attendance_source}｜报销/{payment_source}"
+        return f"来源：出勤={attendance_source}｜报销={payment_source}"
     if attendance_source:
         return f"来源：{attendance_source}"
     if payment_source:


### PR DESCRIPTION
### Motivation
- Users place two CSVs (attendance/施工 and payment/报销) plus `口令.txt` under `data/当前` in arbitrary subfolders and with arbitrary filenames, but the code previously relied on fixed filenames/paths and opaque internal names in outputs. This change makes discovery robust and audit-friendly without touching settlement/calculation logic.

### Description
- Add recursive CSV discovery under `data/当前` using `Path.rglob("*.csv")` and locate `口令.txt` recursively, allowing files in nested subdirectories; updated `tools/demo_settle_person.py` and `tools/demo_settle_project.py` to use this logic. 
- Detect table role by header anchors (attendance/payment keyword lists) and compute `attendance_score`/`payment_score` plus strong-key hits to improve classification and avoid false positives. 
- Selection policy: accept single combined file (if clearly both), accept one attendance + one payment when uniquely identified, otherwise Hard-block and print a candidate report showing relative path, mtime, scores, and a header summary; also print actionable guidance to remove unwanted CSVs. 
- Make source display explicit and transparent: runtime override fields now show relative input paths and presentation changed to `来源：出勤=<path>｜报销=<path>`; no calculation or settlement algorithms were modified. 
- Add/adjust unit tests in `tests/test_demo_settle_person.py` to cover recursive discovery, combined-in-subdir, and ambiguous-candidate blocking behavior.

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully: `77 passed`.
- Confirmed selection/audit behavior via the updated demo tests (`tests/test_demo_settle_person.py`) that exercise single combined, separate CSVs, nested inputs, multiple-candidate blocking, and `口令.txt` discovery, all passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9597315883229e8bda9069d27005)